### PR TITLE
MimeTyper Error Prevention, Removed Unnecessary Code

### DIFF
--- a/cogs/hypixel.py
+++ b/cogs/hypixel.py
@@ -1037,6 +1037,8 @@ class Hypixel(commands.Cog, name="Hypixel"):
                                     description="Please try again in a while!", color=0xff0000)
                 await ctx.send(embed=embed)
                 print(e)
+            if "0, message='Attempt to decode JSON with unexpected mimetype:" in e:
+                await ctx.send('Please enter a valid ign!')
             else:
                 print(e)
                 await self.bot.error_channel.send(f"Error in {ctx.channel.name} while using `g` \n{e}\n<@!326399363943497728>")

--- a/cogs/hypixel.py
+++ b/cogs/hypixel.py
@@ -254,16 +254,16 @@ class Hypixel(commands.Cog, name="Hypixel"):
                 ign = await hypixel.get_dispname(name)
                 rank = await hypixel.get_rank(name)
                 async with aiohttp.ClientSession() as session:
-                        async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{ign}') as resp:
-                            request = resp
-                            request_json = await request.json()
-                            await session.close()
-                uuid = request_json['id']
-                with open('dnkl.json') as f:
-                    data = json.load(f)
+                    async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{ign}') as resp:
+                        request = await resp.json()
+                
                 if request.status != 200:
                     await ctx.send('Unknown IGN!')
                 else:
+                    uuid = request['id']
+                    with open('dnkl.json') as f:
+                        data = json.load(f)
+
                     a, b, c = x.split('/')
                     p, q, r = y.split('/')
 
@@ -296,6 +296,8 @@ class Hypixel(commands.Cog, name="Hypixel"):
                         data.update(dnkl_dict)
                         with open('dnkl.json', 'w') as f:
                             json.dump(data, f)
+                await session.close()
+
             else:
                 await ctx.send("**What is the name of the user you wish to add to the do not kick list?**")
 
@@ -304,18 +306,16 @@ class Hypixel(commands.Cog, name="Hypixel"):
                 ign = await hypixel.get_dispname(name)
                 rank = await hypixel.get_rank(name)
                 async with aiohttp.ClientSession() as session:
-                        async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{ign}') as resp:
-                            request = resp
-                            request_json = await resp.json()
-                            await session.close()
-                uuid = request_json['id']
-
-                with open('dnkl.json') as f:
-                    data = json.load(f)
-
+                    async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{ign}') as resp:
+                        request = await resp.json()
+                
                 if request.status != 200:
                     await ctx.send('Unknown IGN!')
                 else:
+                    uuid = request['id']
+                    with open('dnkl.json') as f:
+                        data = json.load(f)
+
                     await ctx.send("**What is the start date?** (DD/MM/YYYY)")
                     start_date = await self.bot.wait_for('message',
                                                 check=lambda x: x.channel == ctx.channel and x.author == ctx.author)
@@ -364,7 +364,7 @@ class Hypixel(commands.Cog, name="Hypixel"):
                         data.update(dnkl_dict)
                         with open('dnkl.json', 'w') as f:
                             json.dump(data, f)
-
+                await session.close()
 
 
         except Exception as e:
@@ -400,30 +400,30 @@ class Hypixel(commands.Cog, name="Hypixel"):
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
-                    request = resp
-                    if request.status != 200:
-                        await ctx.send('Unknown IGN!')
-                    request = await request.json()
-                    await session.close()
-            ign = request['name']
-            with open("dnkl.json", 'r') as f:
-                data = json.load(f)
+                    request = await resp.json()
+            if request.status != 200:
+                await ctx.send('Unknown IGN!')
+            else:
+                ign = request['name']
+                with open("dnkl.json", 'r') as f:
+                    data = json.load(f)
 
-            if ign not in data.keys():
-                await ctx.send('This player is not on the Do-not-kick-list!')
+                if ign not in data.keys():
+                    await ctx.send('This player is not on the Do-not-kick-list!')
 
-            msgid = f"{data[ign]}"
+                msgid = f"{data[ign]}"
 
-            data.pop(ign)
-            with open('dnkl.json', 'w') as f:
-                json.dump(data, f)
+                data.pop(ign)
+                with open('dnkl.json', 'w') as f:
+                    json.dump(data, f)
 
-            dnkl_channel = self.bot.get_channel(629564802812870657)
+                dnkl_channel = self.bot.get_channel(629564802812870657)
 
-            msg = await dnkl_channel.fetch_message(msgid)
-            await msg.delete()
+                msg = await dnkl_channel.fetch_message(msgid)
+                await msg.delete()
 
-            await ctx.send(f'{ign} has been removed from the do-not-kick-list!')
+                await ctx.send(f'{ign} has been removed from the do-not-kick-list!')
+            await session.close()
 
         except Exception as e:
             if str(e) == "Expecting value: line 1 column 1 (char 0)":
@@ -488,48 +488,47 @@ class Hypixel(commands.Cog, name="Hypixel"):
                 async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
                     request = await resp.json()
 
-                    if resp.status != 200:
-                        await ctx.send('Unknown IGN!')
-                        await session.close()
-                        return
-                    await session.close()
-
-            ign = request["name"]
-            if time in ("None", "Never"):
-                uuid = request['id']
-                embed = discord.Embed(title=f"{rank} {ign}",
-                                    url=f'https://plancke.io/hypixel/player/stats/{ign}', color=0xff0000)
-                embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                embed.add_field(name="IGN:", value=f"{ign}", inline=False)
-                embed.add_field(name="End:", value="Never", inline=False)
-                embed.add_field(name="Reason:", value=f"{reason}", inline=False)
-                embed.set_author(name="Blacklist")
-                await ctx.channel.purge(limit=1)
-                await ctx.send(embed=embed)
+            if resp.status != 200:
+                await ctx.send('Unknown IGN!')
             else:
-                t = time.split('/')
-                a = int(t[0])
-                b = int(t[1])
-                c = int(t[2])
-                if b > 12:
-                    embed = discord.Embed(title='Please enter a valid date!', description="`DD/MM/YYYY`",
-                                        color=0xff0000)
-                    await ctx.send(embed=embed)
-                if b <= 12:
-                    dates = {1: "January", 2: "February", 3: "March", 4: "April", 5: "May", 6: "June", 7: "July", 8: "August", 9: "September", 10: "October", 11: "November", 12: "December"}
-                    end_month = dates.get(b)
-
+                ign = request["name"]
+                if time in ("None", "Never"):
                     uuid = request['id']
                     embed = discord.Embed(title=f"{rank} {ign}",
-                                        url=f'https://plancke.io/hypixel/player/stats/{ign}',
-                                        color=0xff0000)
+                                        url=f'https://plancke.io/hypixel/player/stats/{ign}', color=0xff0000)
                     embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                    embed.add_field(name="IGN:", value=ign, inline=False)
-                    embed.add_field(name="End:", value=f"{a} {end_month} {c}", inline=False)
-                    embed.add_field(name="Reason:", value=reason, inline=False)
+                    embed.add_field(name="IGN:", value=f"{ign}", inline=False)
+                    embed.add_field(name="End:", value="Never", inline=False)
+                    embed.add_field(name="Reason:", value=f"{reason}", inline=False)
                     embed.set_author(name="Blacklist")
                     await ctx.channel.purge(limit=1)
                     await ctx.send(embed=embed)
+                else:
+                    t = time.split('/')
+                    a = int(t[0])
+                    b = int(t[1])
+                    c = int(t[2])
+                    if b > 12:
+                        embed = discord.Embed(title='Please enter a valid date!', description="`DD/MM/YYYY`",
+                                            color=0xff0000)
+                        await ctx.send(embed=embed)
+                    if b <= 12:
+                        dates = {1: "January", 2: "February", 3: "March", 4: "April", 5: "May", 6: "June", 7: "July", 8: "August", 9: "September", 10: "October", 11: "November", 12: "December"}
+                        end_month = dates.get(b)
+
+                        uuid = request['id']
+                        embed = discord.Embed(title=f"{rank} {ign}",
+                                            url=f'https://plancke.io/hypixel/player/stats/{ign}',
+                                            color=0xff0000)
+                        embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                        embed.add_field(name="IGN:", value=ign, inline=False)
+                        embed.add_field(name="End:", value=f"{a} {end_month} {c}", inline=False)
+                        embed.add_field(name="Reason:", value=reason, inline=False)
+                        embed.set_author(name="Blacklist")
+                        await ctx.channel.purge(limit=1)
+                        await ctx.send(embed=embed)
+            await session.close()
+
         except Exception as e:
             if str(e) == "Expecting value: line 1 column 1 (char 0)":
                 embed = discord.Embed(title="The Hypixel API is down!", description="Please try again in a while!", color=0xff0000)
@@ -915,121 +914,120 @@ class Hypixel(commands.Cog, name="Hypixel"):
             else:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
-                        request = resp
-                        if request.status != 200:
-                            await ctx.send('Unknown IGN!')
-                        request = await request.json()
-                        await session.close()
-
-                name = request['name']
-                uuid = request['id']
-                api = hypixel.get_api()
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(f'https://api.hypixel.net/guild?key={api}&player={uuid}') as resp:
-                        req = await resp.json()
-                        await session.close()
-
-                if "guild" not in req or req['guild'] is None:
-                    embed = discord.Embed(title=f"{name}", url=f'https://plancke.io/hypixel/player/stats/{name}',
-                                        color=0xf04747)
-                    embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                    embed.add_field(name="Guildless!",
-                                    value="You must be in a guild for the command to work!")
-                    await ctx.send(embed=embed)
+                        request = await resp.json()
+                if request.status != 200:
+                    await ctx.send('Unknown IGN!')
                 else:
-                    gname = req['guild']['name']
-                    for member in req['guild']["members"]:
-                        if uuid == member["uuid"]:
-                            joined = member['joined']
-                            dt = str(datetime.fromtimestamp(int(str(joined)[:-3])))
-                            dt = (dt[0:10])
-                            rank = member['rank']
-                            if "questParticipation" in member:
-                                cq = member['questParticipation']
-                            else:
-                                cq = 0
-                            expHistory = member['expHistory']
+                    name = request['name']
+                    uuid = request['id']
+                    api = hypixel.get_api()
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(f'https://api.hypixel.net/guild?key={api}&player={uuid}') as resp:
+                            req = await resp.json()
+                            await session.close()
 
-                            totalexp = member['expHistory']
-                            totalexp = sum(totalexp.values())
-
-                            if rank == "Resident":
-                                if totalexp > self.bot.resident_req:
-                                    colour, GraphColor, GraphBorder = hypixel.get_color("res_met")
+                    if "guild" not in req or req['guild'] is None:
+                        embed = discord.Embed(title=f"{name}", url=f'https://plancke.io/hypixel/player/stats/{name}',
+                                            color=0xf04747)
+                        embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                        embed.add_field(name="Guildless!",
+                                        value="You must be in a guild for the command to work!")
+                        await ctx.send(embed=embed)
+                    else:
+                        gname = req['guild']['name']
+                        for member in req['guild']["members"]:
+                            if uuid == member["uuid"]:
+                                joined = member['joined']
+                                dt = str(datetime.fromtimestamp(int(str(joined)[:-3])))
+                                dt = (dt[0:10])
+                                rank = member['rank']
+                                if "questParticipation" in member:
+                                    cq = member['questParticipation']
                                 else:
-                                    colour, GraphColor, GraphBorder = hypixel.get_color("res_not_met")
-                            else:
-                                if totalexp > self.bot.active:
-                                    colour, GraphColor, GraphBorder = hypixel.get_color("active")
-                                elif totalexp > self.bot.inactive:
-                                    colour, GraphColor, GraphBorder = hypixel.get_color("member")
+                                    cq = 0
+                                expHistory = member['expHistory']
+
+                                totalexp = member['expHistory']
+                                totalexp = sum(totalexp.values())
+
+                                if rank == "Resident":
+                                    if totalexp > self.bot.resident_req:
+                                        colour, GraphColor, GraphBorder = hypixel.get_color("res_met")
+                                    else:
+                                        colour, GraphColor, GraphBorder = hypixel.get_color("res_not_met")
                                 else:
-                                    colour, GraphColor, GraphBorder = hypixel.get_color("inactive")
+                                    if totalexp > self.bot.active:
+                                        colour, GraphColor, GraphBorder = hypixel.get_color("active")
+                                    elif totalexp > self.bot.inactive:
+                                        colour, GraphColor, GraphBorder = hypixel.get_color("member")
+                                    else:
+                                        colour, GraphColor, GraphBorder = hypixel.get_color("inactive")
 
-                            totalexp = (format(totalexp, ',d'))
-                            for key, value in expHistory.items():
-                                results.append([key,value])
-                                dates.append(key)
-                                weeklyexp.append(int(value))
-
-
-                            dictionary = {
-                                0: 'Today:',
-                                1: 'Yesterday:',
-                                2: 'Two days ago:',
-                                3: 'Three days ago:',
-                                4: 'Four days ago:',
-                                5: 'Five days ago:',
-                                6: 'Six days ago:'
-                            }
-                            z = 0
-                            gexphistory = ""
-                            for x in results:
-                                if z < 7:
-                                    date = dictionary.get(z, "None")
-                                    gexphistory = gexphistory + f"➤ {date} **{format(weeklyexp[z],',d')}**\n"
-                                    z = z + 1
-
-                                else:
-                                    break
-                            if "commands" not in ctx.channel.name:
-                                name = name.replace("_",        "\_")
-                                await ctx.send(f"__**{name}**__\n**Guild Experience -** `{totalexp}`")
-                            else:
-                                embed = discord.Embed(title=f"{name}",
-                                                    url=f'https://plancke.io/hypixel/player/stats/{name}',
-                                                    color=colour)
-                                embed.set_author(name=gname, url=f'https://plancke.io/hypixel/guild/player/{name}')
-                                embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                                embed.add_field(name="Rank:", value=rank, inline=True)
-                                embed.add_field(name="Joined:", value=dt, inline=True)
-                                embed.add_field(name="Quests Completed:", value=cq, inline=True)
-                                embed.add_field(name="Overall Exp:", value=f"`{totalexp}`", inline=False)
-                                embed.add_field(name="GEXP History", value=gexphistory, inline=False)
+                                totalexp = (format(totalexp, ',d'))
+                                for key, value in expHistory.items():
+                                    results.append([key,value])
+                                    dates.append(key)
+                                    weeklyexp.append(int(value))
 
 
-                                weeklyexp.reverse()
-                                dates.reverse()
-                                chart = QuickChart()
-                                chart.width = 1000
-                                chart.height = 500
-                                chart.background_color = "transparent"
-                                chart.config = {
-                                    "type": "line",
-                                    "data": {
-                                        "labels": dates,
-                                        "datasets": [{
-                                            "label": "Experience",
-                                            "data": weeklyexp,
-                                            "lineTension": 0.4,
-                                            "backgroundColor": GraphColor,
-                                            "borderColor": GraphBorder
-                                        }]
-                                    }
+                                dictionary = {
+                                    0: 'Today:',
+                                    1: 'Yesterday:',
+                                    2: 'Two days ago:',
+                                    3: 'Three days ago:',
+                                    4: 'Four days ago:',
+                                    5: 'Five days ago:',
+                                    6: 'Six days ago:'
                                 }
-                                chart_url = chart.get_url()
-                                embed.set_image(url=chart_url)
-                                await ctx.send(embed=embed)
+                                z = 0
+                                gexphistory = ""
+                                for x in results:
+                                    if z < 7:
+                                        date = dictionary.get(z, "None")
+                                        gexphistory = gexphistory + f"➤ {date} **{format(weeklyexp[z],',d')}**\n"
+                                        z = z + 1
+
+                                    else:
+                                        break
+                                if "commands" not in ctx.channel.name:
+                                    name = name.replace("_",        "\_")
+                                    await ctx.send(f"__**{name}**__\n**Guild Experience -** `{totalexp}`")
+                                else:
+                                    embed = discord.Embed(title=f"{name}",
+                                                        url=f'https://plancke.io/hypixel/player/stats/{name}',
+                                                        color=colour)
+                                    embed.set_author(name=gname, url=f'https://plancke.io/hypixel/guild/player/{name}')
+                                    embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                                    embed.add_field(name="Rank:", value=rank, inline=True)
+                                    embed.add_field(name="Joined:", value=dt, inline=True)
+                                    embed.add_field(name="Quests Completed:", value=cq, inline=True)
+                                    embed.add_field(name="Overall Exp:", value=f"`{totalexp}`", inline=False)
+                                    embed.add_field(name="GEXP History", value=gexphistory, inline=False)
+
+
+                                    weeklyexp.reverse()
+                                    dates.reverse()
+                                    chart = QuickChart()
+                                    chart.width = 1000
+                                    chart.height = 500
+                                    chart.background_color = "transparent"
+                                    chart.config = {
+                                        "type": "line",
+                                        "data": {
+                                            "labels": dates,
+                                            "datasets": [{
+                                                "label": "Experience",
+                                                "data": weeklyexp,
+                                                "lineTension": 0.4,
+                                                "backgroundColor": GraphColor,
+                                                "borderColor": GraphBorder
+                                            }]
+                                        }
+                                    }
+                                    chart_url = chart.get_url()
+                                    embed.set_image(url=chart_url)
+                                    await ctx.send(embed=embed)
+                await session.close()
 
         except Exception as e:
             if str(e) == "Expecting value: line 1 column 1 (char 0)":
@@ -1037,8 +1035,6 @@ class Hypixel(commands.Cog, name="Hypixel"):
                                     description="Please try again in a while!", color=0xff0000)
                 await ctx.send(embed=embed)
                 print(e)
-            if "0, message='Attempt to decode JSON with unexpected mimetype:" in e:
-                await ctx.send('Please enter a valid ign!')
             else:
                 print(e)
                 await self.bot.error_channel.send(f"Error in {ctx.channel.name} while using `g` \n{e}\n<@!326399363943497728>")
@@ -1056,57 +1052,59 @@ class Hypixel(commands.Cog, name="Hypixel"):
                     name = x
             async with aiohttp.ClientSession() as session:
                 async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
-                    request = resp
-                    if request.status != 200:
-                        await ctx.send('Unknown IGN!')
-                    request = await request.json()
-                    await session.close()
-            name = request['name']
-            uuid = request['id']
-            api = hypixel.get_api()
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f'https://api.hypixel.net/guild?key={api}&player={uuid}') as resp:
-                    data = await resp.json()
-                    if data['guild'] == None:
-                        await ctx.send('You are not in a guild!')
-                        return
-                    await session.close()
-            gname = data['guild']['name']
-            if gname != 'Miscellaneous':
-                await ctx.send('The user is not in Miscellaneous')
-            if len(data) < 2:
-                print("The user is not in any guild!")
-                await ctx.send('The user is not in any guild')
-            else:
-                for member in data["guild"]["members"]:
-                    if uuid == member["uuid"]:
-                        member = member
-                        totalexp = member['expHistory']
-                        totalexp = int(sum(totalexp.values()))
-                        if totalexp >= self.bot.dnkl:
-                            eligiblity = True
-                        else:
-                            eligiblity = False
-                        totalexp = (format(totalexp, ',d'))
-                        if eligiblity is False:
-                            embed = discord.Embed(title=name,
-                                                url=f'https://visage.surgeplay.com/full/832/{uuid}',
-                                                color=0xff3333)
-                            embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                            embed.set_author(name="Do-not-kick-list: Eligibility Check")
-                            embed.add_field(name="You are not eligible to apply for the do not kick list.",
-                                            value=f"You need a minimum of {format(self.bot.dnkl,',d')} weekly guild experience.\n You have {totalexp} weekly guild experience.",
-                                            inline=True)
-                        else:
-                            embed = discord.Embed(title=name,
-                                                url=f'https://visage.surgeplay.com/full/832/{uuid}',
-                                                color=0x333cff)
-                            embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                            embed.set_author(name='Do-not-kick-list: Eligibility Check')
-                            embed.add_field(name="You are eligible to apply for the do not kick list.",
-                                            value=f"You meet the minimum of {format(self.bot.dnkl,',d')} weekly guild experience.\n You have {totalexp} weekly guild experience.",
-                                            inline=True)
-                        await ctx.send(embed=embed)
+                    request = await resp.json()  
+
+            if request.status != 200:
+                await ctx.send('Unknown IGN!')
+            else:      
+                name = request['name']
+                uuid = request['id']
+                api = hypixel.get_api()
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(f'https://api.hypixel.net/guild?key={api}&player={uuid}') as resp:
+                        data = await resp.json()
+                        if data['guild'] == None:
+                            await ctx.send('You are not in a guild!')
+                            return
+                        await session.close()
+                gname = data['guild']['name']
+                if gname != 'Miscellaneous':
+                    await ctx.send('The user is not in Miscellaneous')
+                if len(data) < 2:
+                    print("The user is not in any guild!")
+                    await ctx.send('The user is not in any guild')
+                else:
+                    for member in data["guild"]["members"]:
+                        if uuid == member["uuid"]:
+                            member = member
+                            totalexp = member['expHistory']
+                            totalexp = int(sum(totalexp.values()))
+                            if totalexp >= self.bot.dnkl:
+                                eligiblity = True
+                            else:
+                                eligiblity = False
+                            totalexp = (format(totalexp, ',d'))
+                            if eligiblity is False:
+                                embed = discord.Embed(title=name,
+                                                    url=f'https://visage.surgeplay.com/full/832/{uuid}',
+                                                    color=0xff3333)
+                                embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                                embed.set_author(name="Do-not-kick-list: Eligibility Check")
+                                embed.add_field(name="You are not eligible to apply for the do not kick list.",
+                                                value=f"You need a minimum of {format(self.bot.dnkl,',d')} weekly guild experience.\n You have {totalexp} weekly guild experience.",
+                                                inline=True)
+                            else:
+                                embed = discord.Embed(title=name,
+                                                    url=f'https://visage.surgeplay.com/full/832/{uuid}',
+                                                    color=0x333cff)
+                                embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                                embed.set_author(name='Do-not-kick-list: Eligibility Check')
+                                embed.add_field(name="You are eligible to apply for the do not kick list.",
+                                                value=f"You meet the minimum of {format(self.bot.dnkl,',d')} weekly guild experience.\n You have {totalexp} weekly guild experience.",
+                                                inline=True)
+                            await ctx.send(embed=embed)
+            await session.close()
+
         except Exception as e:
             if str(e) == "Expecting value: line 1 column 1 (char 0)":
                 embed = discord.Embed(title="The Hypixel API is down!", description="Please try again in a while!", color=0xff0000)

--- a/cogs/staff.py
+++ b/cogs/staff.py
@@ -421,98 +421,97 @@ class staff(commands.Cog, name="Staff"):
                         xl_members.append(response)
 
 
-            if staff in ctx.author.roles:  # Making sure that the user is Staff
-                for guild in self.bot.guilds:
-                    if str(guild) == "Miscellaneous [MISC]":  # Check if the Discord is Miscellaneous
-                        for member in guild.members:  # For loop for all members in the Discord
-                            if member.id != '326399363943497728' and member.bot is False:
-                                name = member.nick  # Obtaining their nick
-                                if name is None:  # If they don't have a nick, it uses their name.
-                                    name = member.name
+            for guild in self.bot.guilds:
+                if str(guild) == "Miscellaneous [MISC]":  # Check if the Discord is Miscellaneous
+                    for member in guild.members:  # For loop for all members in the Discord
+                        if member.id != '326399363943497728' and member.bot is False:
+                            name = member.nick  # Obtaining their nick
+                            if name is None:  # If they don't have a nick, it uses their name.
+                                name = member.name
 
-                                else:
-                                    message = await ctx.send(f"Checking {name}")
+                            else:
+                                message = await ctx.send(f"Checking {name}")
 
-                                    async with aiohttp.ClientSession() as session:
-                                        async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
-                                            mojang = resp
-                                    
-                                    if mojang.status != 200:  # If the IGN is invalid
-                                        await member.remove_roles(member_role, guest)
-                                        await member.add_roles(new_member)
-                                        await message.edit(content=
-                                                        f"{name} ||{member}|| Player doesn't exist. **++New Member | --Member | -- Guest**")
-                                    elif guild_master not in member.roles:
-                                        mojang_json = await mojang.json()
-                                        ign = mojang_json["name"]
-                                        uuid = mojang_json['id']
-                                        await member.edit(nick=ign)
-
-
-                                        #Miscellaneous
-                                        if ign in misc_members and ign != "Rowdies":
-                                            async with aiohttp.ClientSession() as session:
-                                                async with session.get(f"https://api.hypixel.net/guild?key={await hypixel.get_api()}&player={uuid}") as resp:
-                                                    req = await resp.json()
+                                async with aiohttp.ClientSession() as session:
+                                    async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
+                                        mojang = resp
+                                
+                                if mojang.status != 200:  # If the IGN is invalid
+                                    await member.remove_roles(member_role, guest)
+                                    await member.add_roles(new_member)
+                                    await message.edit(content=
+                                                    f"{name} ||{member}|| Player doesn't exist. **++New Member | --Member | -- Guest**")
+                                elif guild_master not in member.roles:
+                                    mojang_json = await mojang.json()
+                                    ign = mojang_json["name"]
+                                    uuid = mojang_json['id']
+                                    await member.edit(nick=ign)
 
 
-                                            if member_role not in member.roles:
-                                                await member.add_roles(member)
-                                                await member.remove_roles(new_member, guest)
-
-                                            for user in req['guild']["members"]:
-                                                if uuid == user["uuid"]:
-                                                    totalexp = user['expHistory']
-                                                    totalexp = sum(totalexp.values())
-                                                    usergrank = user['rank']
-
-                                                if usergrank != 'Resident':
-                                                    if totalexp < self.bot.inactive:
-                                                        await member.add_roles(inactive_role)
-                                                        await member.remove_roles(active_role)
-                                                        await message.edit(
-                                                            content=f"{name} ||{member}|| **++Member \| ++Inactive \| --Active**")
-
-                                                    elif totalexp >= self.bot.active:  # If the member is active
-                                                        await member.remove_roles(inactive_role, new_member)
-                                                        await member.add_roles(active_role)
-                                                        await message.edit(
-                                                            content=f"{name} ||{member}|| **++Member \| ++Active \| --Inactive**")
-
-                                                    elif totalexp > self.bot.inactive:
-                                                        await member.remove_roles(inactive_role, active_role)
-                                                        await message.edit(
-                                                            content=f"{name} ||{member}|| **++Member \| --Inactive\| --Active**")
-                                                else:
-                                                    if totalexp < 50000:
-                                                        await member.add_roles(inactive_role)
-                                                        await member.remove_roles(active_role)
-                                                        await message.edit(
-                                                            content=f"{name} ||{member}|| **++Member \| ++Inactive \| --Active**")
-
-                                                    elif totalexp >= self.bot.active:  # If the member is active
-                                                        await member.remove_roles(inactive_role, new_member)
-                                                        await member.add_roles(active_role)
-                                                        await message.edit(
-                                                            content=f"{name} ||{member}|| **++Member \| ++Active \| --Inactive**")
-
-                                                    elif totalexp > 50000:
-                                                        await member.remove_roles(inactive_role, active_role)
-                                                        await message.edit(
-                                                            content=f"{name} ||{member}|| **++Member \| --Inactive\| --Active**")
-
-                                                
+                                    #Miscellaneous
+                                    if ign in misc_members and ign != "Rowdies":
+                                        async with aiohttp.ClientSession() as session:
+                                            async with session.get(f"https://api.hypixel.net/guild?key={await hypixel.get_api()}&player={uuid}") as resp:
+                                                req = await resp.json()
 
 
-                                        elif ign in xl_members:
-                                            await member.add_roles(guest, xl_ally)
-                                            await member.remove_roles(member_role, new_member, active_role)
-                                            await message.edit(content=f"{name} ||{member}|| Member of XL **++XL - Ally \| ++Guest | --Member | --Active**")
+                                        if member_role not in member.roles:
+                                            await member.add_roles(member)
+                                            await member.remove_roles(new_member, guest)
 
-                                        else:
-                                            await member.add_roles(guest)
-                                            await member.remove_roles(member_role, new_member, active_role)
-                                            await message.edit(content=f"{name} ||{member}|| Member of an unallied guild **++Guest | --Member | --Active**")
+                                        for user in req['guild']["members"]:
+                                            if uuid == user["uuid"]:
+                                                totalexp = user['expHistory']
+                                                totalexp = sum(totalexp.values())
+                                                usergrank = user['rank']
+
+                                            if usergrank != 'Resident':
+                                                if totalexp < self.bot.inactive:
+                                                    await member.add_roles(inactive_role)
+                                                    await member.remove_roles(active_role)
+                                                    await message.edit(
+                                                        content=f"{name} ||{member}|| **++Member \| ++Inactive \| --Active**")
+
+                                                elif totalexp >= self.bot.active:  # If the member is active
+                                                    await member.remove_roles(inactive_role, new_member)
+                                                    await member.add_roles(active_role)
+                                                    await message.edit(
+                                                        content=f"{name} ||{member}|| **++Member \| ++Active \| --Inactive**")
+
+                                                elif totalexp > self.bot.inactive:
+                                                    await member.remove_roles(inactive_role, active_role)
+                                                    await message.edit(
+                                                        content=f"{name} ||{member}|| **++Member \| --Inactive\| --Active**")
+                                            else:
+                                                if totalexp < 50000:
+                                                    await member.add_roles(inactive_role)
+                                                    await member.remove_roles(active_role)
+                                                    await message.edit(
+                                                        content=f"{name} ||{member}|| **++Member \| ++Inactive \| --Active**")
+
+                                                elif totalexp >= self.bot.active:  # If the member is active
+                                                    await member.remove_roles(inactive_role, new_member)
+                                                    await member.add_roles(active_role)
+                                                    await message.edit(
+                                                        content=f"{name} ||{member}|| **++Member \| ++Active \| --Inactive**")
+
+                                                elif totalexp > 50000:
+                                                    await member.remove_roles(inactive_role, active_role)
+                                                    await message.edit(
+                                                        content=f"{name} ||{member}|| **++Member \| --Inactive\| --Active**")
+
+                                            
+
+
+                                    elif ign in xl_members:
+                                        await member.add_roles(guest, xl_ally)
+                                        await member.remove_roles(member_role, new_member, active_role)
+                                        await message.edit(content=f"{name} ||{member}|| Member of XL **++XL - Ally \| ++Guest | --Member | --Active**")
+
+                                    else:
+                                        await member.add_roles(guest)
+                                        await member.remove_roles(member_role, new_member, active_role)
+                                        await message.edit(content=f"{name} ||{member}|| Member of an unallied guild **++Guest | --Member | --Active**")
 
             inactivity_channel = self.bot.get_channel(848067712156434462)
 
@@ -722,61 +721,60 @@ class staff(commands.Cog, name="Staff"):
                         xl_members.append(response)
 
 
-            if staff in ctx.author.roles:  # Making sure that the user is Staff
-                for guild in self.bot.guilds:
-                    if str(guild) == "Miscellaneous [MISC]":  # Check if the Discord is Miscellaneous
-                        for member in guild.members:  # For loop for all members in the Discord
-                            if not member.bot:
-                                discord_members.append(member)
+            for guild in self.bot.guilds:
+                if str(guild) == "Miscellaneous [MISC]":  # Check if the Discord is Miscellaneous
+                    for member in guild.members:  # For loop for all members in the Discord
+                        if not member.bot:
+                            discord_members.append(member)
 
-                invalid_names = active_names = inactive_names = member_names = xl_names = ""
-                for member in discord_members:
-                    name = member.nick  # Obtaining their nick
-                    if name is None:  # If they don't have a nick, it uses their name.
-                        name = member.name
+            invalid_names = active_names = inactive_names = member_names = xl_names = ""
+            for member in discord_members:
+                name = member.nick  # Obtaining their nick
+                if name is None:  # If they don't have a nick, it uses their name.
+                    name = member.name
 
-                    name = '_' + name
+                name = '_' + name
 
-                    if name.isidentifier() is False:
-                        await member.remove_roles(member_role, guest)
-                        await member.add_roles(new_member)
+                if name.isidentifier() is False:
+                    await member.remove_roles(member_role, guest)
+                    await member.add_roles(new_member)
 
-                        invalid_names = invalid_names + str(member) + "\n"
-                        discord_members.pop(discord_members.index(member))
+                    invalid_names = invalid_names + str(member) + "\n"
+                    discord_members.pop(discord_members.index(member))
 
-                    name = member.nick  # Obtaining their nick
-                    if name is None:  # If they don't have a nick, it uses their name.
-                        name = member.name
+                name = member.nick  # Obtaining their nick
+                if name is None:  # If they don't have a nick, it uses their name.
+                    name = member.name
 
-                    for element in misc_details:
-                        if name in element[0]:
-                            if element[1] > self.bot.active:
-                                active_members.append(member)
-                                active_names = active_names + str(member) + "\n"
-                            elif element[1] > self.bot.inactive:
-                                if member_role not in member.roles:
-                                    regular_members.append(member)
-                                    member_names = member_names + str(member) + "\n"
-                            elif element[1] < self.bot.inactive:
-                                inactive_members.append(member)
-                                inactive_names = inactive_names + str(member) + "\n"
+                for element in misc_details:
+                    if name in element[0]:
+                        if element[1] > self.bot.active:
+                            active_members.append(member)
+                            active_names = active_names + str(member) + "\n"
+                        elif element[1] > self.bot.inactive:
+                            if member_role not in member.roles:
+                                regular_members.append(member)
+                                member_names = member_names + str(member) + "\n"
+                        elif element[1] < self.bot.inactive:
+                            inactive_members.append(member)
+                            inactive_names = inactive_names + str(member) + "\n"
 
-                    if name in xl_members:
-                        if xl_ally not in member.roles:
-                            xl_discord_members.append(member)
-                            xl_names = xl_names + str(member) + "\n"
-                    else:
-                        guest_list.append(member)
-                invalid_embed = discord.Embed(title="Invalid: Given @New Member", description=invalid_names, color=0x620B06)
-                active_embed = discord.Embed(title="Active: Given @Active", description=active_names, color=0x0073BF)
-                member_embed = discord.Embed(title="Member: Given @Member", description=member_names, color=0x4DFF00)
-                inactive_embed = discord.Embed(title="Inactive: Given @inactive", description=inactive_names, color=0xFF4C6E)
-                xl_embed = discord.Embed(title="XL: Given @xl_ally", description=xl_names, color=0xA05E75)
-                await ctx.send(embed=invalid_embed)
-                await ctx.send(embed=active_embed)
-                await ctx.send(embed=member_embed)
-                await ctx.send(embed=inactive_embed)
-                await ctx.send(embed=xl_embed)
+                if name in xl_members:
+                    if xl_ally not in member.roles:
+                        xl_discord_members.append(member)
+                        xl_names = xl_names + str(member) + "\n"
+                else:
+                    guest_list.append(member)
+            invalid_embed = discord.Embed(title="Invalid: Given @New Member", description=invalid_names, color=0x620B06)
+            active_embed = discord.Embed(title="Active: Given @Active", description=active_names, color=0x0073BF)
+            member_embed = discord.Embed(title="Member: Given @Member", description=member_names, color=0x4DFF00)
+            inactive_embed = discord.Embed(title="Inactive: Given @inactive", description=inactive_names, color=0xFF4C6E)
+            xl_embed = discord.Embed(title="XL: Given @xl_ally", description=xl_names, color=0xA05E75)
+            await ctx.send(embed=invalid_embed)
+            await ctx.send(embed=active_embed)
+            await ctx.send(embed=member_embed)
+            await ctx.send(embed=inactive_embed)
+            await ctx.send(embed=xl_embed)
 
 
 

--- a/cogs/ticket.py
+++ b/cogs/ticket.py
@@ -18,108 +18,105 @@ class Tickets(commands.Cog, name="Tickets"):
                         async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
                             request = await resp.json()
 
-                            if resp.status != 200:
-                                await ctx.send('Please enter a valid ign!')
-                            else:
-                                ign = request['name']
-                                uuid = request['id']
+                        if request.status != 200:
+                            await ctx.send('Please enter a valid ign!')
+                        else:
+                            ign = request['name']
+                            uuid = request['id']
 
-                                guild_name = await hypixel.get_guild(name)
-                                newmember = discord.utils.get(ctx.guild.roles, name="New Member")
-                                awaiting_app = discord.utils.get(ctx.guild.roles, name="Awaiting Approval")
-                                member = discord.utils.get(ctx.guild.roles, name="Member")
-                                guest = discord.utils.get(ctx.guild.roles, name="Guest")
-                                staff = discord.utils.get(ctx.guild.roles, name="Staff")
-                                officer = discord.utils.get(ctx.guild.roles, name="Officer")
-                                tofficer = discord.utils.get(ctx.guild.roles, name="Trial Officer")
-                                xl_ally = discord.utils.get(ctx.guild.roles, name="XL - Ally")
-
-
-                                nick = await author.edit(nick=ign)
-                                if guild_name == "Miscellaneous":
-                                    await ctx.author.remove_roles(newmember)
-
-                                    await ctx.channel.purge(limit=1)
-                                    embed = discord.Embed(title="Registration successful!")
-                                    embed.add_field(name=ign,
-                                                    value="Member of Miscellaneous")
-
-                                    embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                                    await ctx.send(embed=embed)
-                                    await ctx.author.add_roles(member)
-
-                                elif guild_name == "XL":
-                                    await ctx.author.remove_roles(newmember)
-                                    await ctx.author.add_roles(guest, xl_ally)
+                            guild_name = await hypixel.get_guild(name)
+                            newmember = discord.utils.get(ctx.guild.roles, name="New Member")
+                            awaiting_app = discord.utils.get(ctx.guild.roles, name="Awaiting Approval")
+                            member = discord.utils.get(ctx.guild.roles, name="Member")
+                            guest = discord.utils.get(ctx.guild.roles, name="Guest")
+                            staff = discord.utils.get(ctx.guild.roles, name="Staff")
+                            officer = discord.utils.get(ctx.guild.roles, name="Officer")
+                            tofficer = discord.utils.get(ctx.guild.roles, name="Trial Officer")
+                            xl_ally = discord.utils.get(ctx.guild.roles, name="XL - Ally")
 
 
-                                    await ctx.channel.purge(limit=1)
-                                    embed = discord.Embed(title="Registration successful!")
-                                    embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                                    embed.add_field(name=ign, value="Member of XL")
-                                    await ctx.send(embed=embed)
+                            nick = await author.edit(nick=ign)
+                            if guild_name == "Miscellaneous":
+                                await ctx.author.remove_roles(newmember)
 
-                                elif guild_name not in ("Miscellaneous", "XL"):
-                                    await ctx.author.remove_roles(newmember)
-                                    await ctx.author.add_roles(awaiting_app)
-                                    if nick is None:
-                                        nick = author.name
+                                await ctx.channel.purge(limit=1)
+                                embed = discord.Embed(title="Registration successful!")
+                                embed.add_field(name=ign,
+                                                value="Member of Miscellaneous")
 
-                                    await ctx.channel.purge(limit=1)
-                                    embed = discord.Embed(title="Registration successful!")
-                                    embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
-                                    embed.add_field(name=ign, value="New Member")
-                                    await ctx.send(embed=embed)
+                                embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                                await ctx.send(embed=embed)
+                                await ctx.author.add_roles(member)
 
-                                    category = discord.utils.get(ctx.guild.categories, name="RTickets")
-                                    ticket_channel = await ctx.guild.create_text_channel(f"registration-ticket-{nick}",
-                                                                                        category=category)
-                                    await ticket_channel.set_permissions(ctx.guild.get_role(ctx.guild.id), send_messages=False,
-                                                                        read_messages=False)
-                                    await ticket_channel.set_permissions(staff, send_messages=True, read_messages=True,
-                                                                        add_reactions=True, embed_links=True, attach_files=True,
-                                                                        read_message_history=True, external_emojis=True)
-                                    await ticket_channel.set_permissions(officer, send_messages=True, read_messages=True,
-                                                                        add_reactions=True, embed_links=True, attach_files=True,
-                                                                        read_message_history=True, external_emojis=True)
-                                    await ticket_channel.set_permissions(tofficer, send_messages=True, read_messages=True,
-                                                                        add_reactions=True, embed_links=True, attach_files=True,
-                                                                        read_message_history=True, external_emojis=True)
-                                    await ticket_channel.set_permissions(author, send_messages=True, read_messages=True,
-                                                                        add_reactions=True, embed_links=True, attach_files=True,
-                                                                        read_message_history=True, external_emojis=True)
-                                    await ticket_channel.set_permissions(newmember, send_messages=False, read_messages=False,
-                                                                        add_reactions=True, embed_links=True, attach_files=True,
-                                                                        read_message_history=True, external_emojis=True)
+                            elif guild_name == "XL":
+                                await ctx.author.remove_roles(newmember)
+                                await ctx.author.add_roles(guest, xl_ally)
 
-                                    embed = discord.Embed(title="Miscellaneous Guild Requirements", description="These requirements are subject to change!", color=0x8368ff)
-                                    embed.add_field(name="Active",
-                                                    value=f"•  {format(self.bot.active,',d')} Weekly Guild Experience",
-                                                    inline=False)
-                                    embed.add_field(name="DNKL Eligibility",
-                                                    value=f"•  {format(self.bot.dnkl,',d')} Weekly Guild Experience",
-                                                    inline=False)
-                                    embed.add_field(name="Resident",
-                                                    value=f"•  {format(self.bot.resident_req,',d')} Weekly Guild Experience",
-                                                    inline=False)
-                                    embed.add_field(name="Member",
-                                                    value=f"•  {format(self.bot.inactive,',d')} Weekly Guild Experience",
-                                                    inline=False)
-                                    embed.add_field(name="New Member",
-                                                    value=f"•  {format(self.bot.new_member,',d')} Daily Guild Experience",
-                                                    inline=False)
-                                    embed.set_footer(text="You are considered a New Member for the first 7 days after joining the guild"
-                                                        "\nIf you fail to meet the New Member/Member requirements, you will be kicked!")
-                                    await ctx.author.send(embed=embed)
-                            await session.close()
+
+                                await ctx.channel.purge(limit=1)
+                                embed = discord.Embed(title="Registration successful!")
+                                embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                                embed.add_field(name=ign, value="Member of XL")
+                                await ctx.send(embed=embed)
+
+                            elif guild_name not in ("Miscellaneous", "XL"):
+                                await ctx.author.remove_roles(newmember)
+                                await ctx.author.add_roles(awaiting_app)
+                                if nick is None:
+                                    nick = author.name
+
+                                await ctx.channel.purge(limit=1)
+                                embed = discord.Embed(title="Registration successful!")
+                                embed.set_thumbnail(url=f'https://visage.surgeplay.com/full/832/{uuid}')
+                                embed.add_field(name=ign, value="New Member")
+                                await ctx.send(embed=embed)
+
+                                category = discord.utils.get(ctx.guild.categories, name="RTickets")
+                                ticket_channel = await ctx.guild.create_text_channel(f"registration-ticket-{nick}",
+                                                                                    category=category)
+                                await ticket_channel.set_permissions(ctx.guild.get_role(ctx.guild.id), send_messages=False,
+                                                                    read_messages=False)
+                                await ticket_channel.set_permissions(staff, send_messages=True, read_messages=True,
+                                                                    add_reactions=True, embed_links=True, attach_files=True,
+                                                                    read_message_history=True, external_emojis=True)
+                                await ticket_channel.set_permissions(officer, send_messages=True, read_messages=True,
+                                                                    add_reactions=True, embed_links=True, attach_files=True,
+                                                                    read_message_history=True, external_emojis=True)
+                                await ticket_channel.set_permissions(tofficer, send_messages=True, read_messages=True,
+                                                                    add_reactions=True, embed_links=True, attach_files=True,
+                                                                    read_message_history=True, external_emojis=True)
+                                await ticket_channel.set_permissions(author, send_messages=True, read_messages=True,
+                                                                    add_reactions=True, embed_links=True, attach_files=True,
+                                                                    read_message_history=True, external_emojis=True)
+                                await ticket_channel.set_permissions(newmember, send_messages=False, read_messages=False,
+                                                                    add_reactions=True, embed_links=True, attach_files=True,
+                                                                    read_message_history=True, external_emojis=True)
+
+                                embed = discord.Embed(title="Miscellaneous Guild Requirements", description="These requirements are subject to change!", color=0x8368ff)
+                                embed.add_field(name="Active",
+                                                value=f"•  {format(self.bot.active,',d')} Weekly Guild Experience",
+                                                inline=False)
+                                embed.add_field(name="DNKL Eligibility",
+                                                value=f"•  {format(self.bot.dnkl,',d')} Weekly Guild Experience",
+                                                inline=False)
+                                embed.add_field(name="Resident",
+                                                value=f"•  {format(self.bot.resident_req,',d')} Weekly Guild Experience",
+                                                inline=False)
+                                embed.add_field(name="Member",
+                                                value=f"•  {format(self.bot.inactive,',d')} Weekly Guild Experience",
+                                                inline=False)
+                                embed.add_field(name="New Member",
+                                                value=f"•  {format(self.bot.new_member,',d')} Daily Guild Experience",
+                                                inline=False)
+                                embed.set_footer(text="You are considered a New Member for the first 7 days after joining the guild"
+                                                    "\nIf you fail to meet the New Member/Member requirements, you will be kicked!")
+                                await ctx.author.send(embed=embed)
+                        await session.close()
                 else:
                     await ctx.send('This command can only be used in the registration channel!')
         except Exception as e:
-            if "0, message='Attempt to decode JSON with unexpected mimetype:" in e:
-                await ctx.send('Please enter a valid ign!')
-            else:
-                print(e)
-                await self.bot.error_channel.send(f"Error in {ctx.channel.name} while trying to use `register`\n{e}\n<@!326399363943497728>")
+            print(e)
+            await self.bot.error_channel.send(f"Error in {ctx.channel.name} while trying to use `register`\n{e}\n<@!326399363943497728>")
 
     @commands.command(aliases=['del'])
     async def delete(self, ctx):


### PR DESCRIPTION
Did MimeType error prevention the non-lazy way for what was done the lazy way (',gmember' and ',register').
Added the prevention for ',dnklcheck', ',dnkladd' ',dnklremove', and ',blacklist'

Removed 2 unnecessary if statements from ',rolcheck' and ',newrolecheck', as the 'Staff' role is already a requirement of using those commands.