### PR TITLE
Weird Cleanup

### DIFF
--- a/cogs/hypixel.py
+++ b/cogs/hypixel.py
@@ -259,7 +259,7 @@ class Hypixel(commands.Cog, name="Hypixel"):
                         embed.add_field(name="Reason", value=f"{reason}", inline=False)
                         embed.set_author(name="Do not kick list")
                         await ctx.channel.purge(limit=1)
-                        message = await ctx.send(embed=embed)
+                        message = await self.bot.dnkl_channel.send(embed=embed)
 
                         dnkl_dict = {ign: message.id}
 

--- a/cogs/staff.py
+++ b/cogs/staff.py
@@ -278,7 +278,7 @@ class staff(commands.Cog, name="Staff"):
         misc_uuids, xl_uuids, = await hypixel.get_guild_members("Miscellaneous"), await hypixel.get_guild_members("XL")
 
 
-        misc_members, calm_members, xl_members= [], [], []
+        misc_members, xl_members= [], []
 
         #Miscellaneous Member Names
         await msg.edit(content="**Processing** - 1/2")

--- a/cogs/utils/hypixel.py
+++ b/cogs/utils/hypixel.py
@@ -172,7 +172,7 @@ async def get_gtag(name):
 async def get_dispnameID(name):
     async with aiohttp.ClientSession() as session:
         async with session.get(f'https://api.mojang.com/users/profiles/minecraft/{name}') as resp:
-            request = await resp.json()
+            request = await resp.json(content_type=None)
             await session.close()
     if 'error' not in request:
         ign = request["name"]


### PR DESCRIPTION
Made the shorthand ,dnkladd send messages  to the dnkl_channel.
Removed old allies from ,rolecheck.
Added ,fs MimeType protection.